### PR TITLE
Fix tests to match new header title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Restaurant Explorer</title>
+    <title>Top Asian Noodles</title>
   </head>
   <body>
     <div id="root"></div>

--- a/specs/implementation_plan.md
+++ b/specs/implementation_plan.md
@@ -107,7 +107,7 @@ The Vite build requires an HTML entry point at project root:
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Restaurant Explorer</title>
+    <title>Top Asian Noodles</title>
   </head>
   <body>
     <div id="root"></div>

--- a/tests/client/Header.test.tsx
+++ b/tests/client/Header.test.tsx
@@ -5,7 +5,7 @@ import Header from '../../src/client/components/Header';
 describe('Header component', () => {
   it('renders the title text', () => {
     render(<Header />);
-    const heading = screen.getByText('Restaurant Explorer');
+    const heading = screen.getByText('Top Asian Noodles');
     expect(heading).toBeDefined();
   });
 });

--- a/tests/e2e/basic.spec.ts
+++ b/tests/e2e/basic.spec.ts
@@ -4,7 +4,7 @@ test('homepage loads and shows map', async ({ page }) => {
   await page.goto('/');
   
   // Check for header text
-  await expect(page.locator('h1')).toContainText('Restaurant Explorer');
+  await expect(page.locator('h1')).toContainText('Top Asian Noodles');
   
   // Check if map container is rendered
   await expect(page.locator('.leaflet-container')).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -4,9 +4,9 @@ test('homepage has title and header', async ({ page }) => {
   await page.goto('/');
   
   // Check page title
-  await expect(page).toHaveTitle(/Restaurant Explorer/);
+  await expect(page).toHaveTitle(/Top Asian Noodles/);
   
   // Check for header content
   const header = page.locator('h1');
-  await expect(header).toContainText('Restaurant Explorer');
+  await expect(header).toContainText('Top Asian Noodles');
 });


### PR DESCRIPTION
## Summary
- update HTML title
- update implementation plan snippet
- fix Header test expectation
- update e2e specs for new header text

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm run test:api` *(fails: jest not found)*